### PR TITLE
search for "use strict" throughout code, not just at beginning of code

### DIFF
--- a/app/compiler.js
+++ b/app/compiler.js
@@ -61,7 +61,7 @@ export class Compiler extends Component {
 
   prepareCode(code) {
     // Strict mode fixes strange evaluation issues in Chrome.
-    if (code.indexOf('use strict') !== 0) {
+    if (code.indexOf('use strict') < 0) {
       return `'use strict'\n${code}`
     }
     return code


### PR DESCRIPTION
a browserified bundle does not include 'use strict' at code[0], and inserting 'use strict' before the bundle breaks things.

Hopefully, this change won't cause other scripts to break.

Here's an example to browserify and compare master to this pull request:

``` javascript
navigator.getUserMedia = navigator.getUserMedia || navigator.webkitGetUserMedia || navigator.mozGetUserMedia

setTimeout(function () {
  console.log(global.analyser.frequencies())
}, 2000)

const { totalCols } = global.config

function visualizer (currentLights, time) {
  // const colIndex = Math.round(time * 20 % totalCols)
  const samples = global.analyser.frequencies()
  const lights = totalCols

  const samplesPerLight = Math.floor(samples.length / lights)
  console.log(samplesPerLight)

  // console.log('got freq:', frequencies)

  const newLights = new global.Lights()

  for (let i = 0; i < totalCols; i++) {
    let segment = samples.slice(samplesPerLight * i, samplesPerLight * (i + 1))
    if (samples.length > 0) {
      let sum = 0
      for (var j = 0; j < segment.length; ++j) {
        sum = sum + segment[j]
      }
      let intensity = Math.floor(((sum + 1) / segment.length) / 256 * 100)
      console.log('segment', i, intensity, segment)
      let color = global.Color().hsl(time * 25 % 360, 100, Math.floor((intensity + 1) / 256 * 100))
      newLights.set(i, color)
    }
  }

  return newLights
}

navigator.webkitGetUserMedia({
  video: false,
  audio: true
}, function (mediaStream) {
  var stream = require('audio-stream')(mediaStream, {
    channels: 1,
    volume: 0.5
  })

  global.analyser = require('web-audio-analyser')(mediaStream, {
    stereo: false,
    audible: false
  })

  stream.on('header', function (header) {
    // Wave header properties
  })

  console.log(stream)

  stream.on('data', function (data) {
    // console.log('got data', data)
    // Data is a Buffer instance (UInt8Array)
  })

  stream.on('end', function () {
    // End is emitted when media stream has ended
  })

  global.register(visualizer)
}, function () {
  console.log('Failed to get media')
})
```
